### PR TITLE
Parannettu "vainLisatytLuvutLoytyvat" testiä

### DIFF
--- a/koodi/viikko4/IntJoukkoSovellus/src/test/java/ohtu/intjoukkosovellus/IntJoukkoTest.java
+++ b/koodi/viikko4/IntJoukkoSovellus/src/test/java/ohtu/intjoukkosovellus/IntJoukkoTest.java
@@ -33,6 +33,7 @@ public class IntJoukkoTest {
     public void vainLisatytLuvutLoytyvat() {
         assertTrue(joukko.kuuluu(10));
         assertFalse(joukko.kuuluu(5));
+        assertFalse(joukko.kuuluu(0));
         assertTrue(joukko.kuuluu(3));
     }
 


### PR DESCRIPTION
Testi tarkistaa ettei luku 0 löydy. Tällein kävisi jos metodissa tarkastellaan suoraan lukujen taulukkoa.